### PR TITLE
Add hostname argument for install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Dash for automatically consolidating addresses and service links for a Proxmox h
 Install on your Proxmox host with:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/Jake-Fieldhouse/ProxMoxWtfDash/main/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Jake-Fieldhouse/ProxMoxWtfDash/main/install.sh) [hostname]
 ```
 
-The dashboard will then be available at `http://wtf-proxmoxdash.hosted.jke:8750` and at `http://<lan-ip>:8750`.
+Replace `[hostname]` with your desired hostname (default `wtf`). For example:
+
+```bash
+install.sh myhost
+```
+
+The dashboard will then be available at `http://[hostname]-proxmoxdash.hosted.jke:8750` and at `http://<lan-ip>:8750`.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
+HOST=${1:-wtf}
 SERVICE=wtf-proxmoxdash
 INSTALL_DIR=/opt/$SERVICE
 LOG_FILE=/var/log/$SERVICE.log
+DOMAIN="${HOST}-proxmoxdash.hosted.jke"
 
 if [ "$EUID" -ne 0 ]; then
     echo "Run as root" >&2
@@ -42,9 +44,9 @@ fi
 pip3 install --break-system-packages -r "$INSTALL_DIR/requirements.txt"
 
 CUR_HOST=$(hostname)
-if [ "$CUR_HOST" != "$SERVICE" ]; then
-    hostnamectl set-hostname "$SERVICE"
-    tailscale set --hostname "$SERVICE" >/dev/null 2>&1 || true
+if [ "$CUR_HOST" != "$HOST" ]; then
+    hostnamectl set-hostname "$HOST"
+    tailscale set --hostname "$HOST" >/dev/null 2>&1 || true
     systemctl restart tailscaled || true
 fi
 
@@ -71,5 +73,5 @@ systemctl enable --now $SERVICE
 
 LAN_IP=$(hostname -I | awk '{print $1}')
 TS_IP=$(tailscale ip -4 2>/dev/null | head -n1)
-echo "$SERVICE running at http://wtf-proxmoxdash.hosted.jke:8750 and http://${LAN_IP}:8750${TS_IP:+ and http://${TS_IP}:8750}"
+echo "$SERVICE running at http://${DOMAIN}:8750 and http://${LAN_IP}:8750${TS_IP:+ and http://${TS_IP}:8750}"
 


### PR DESCRIPTION
## Summary
- allow install.sh to take an optional hostname argument
- show hostname usage in the README

## Testing
- `grep -n "<<<<<<<\|=======\|>>>>>>>" -R .`
- `bash -n install.sh`
- `python3 -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_685d367542f083308ca5db0dc5e46b0b